### PR TITLE
Change the way we use the link line for executables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,8 @@ ADD_LIBRARY(libmepbm
 ### Describe the main executable and from which files
 ### it needs to be compiled.
 ADD_EXECUTABLE(mepbm
-	       main.cpp)
-TARGET_LINK_LIBRARIES(mepbm
-                      $<TARGET_OBJECTS:libmepbm>)
+	       main.cpp
+               $<TARGET_OBJECTS:libmepbm>)
 TARGET_LINK_LIBRARIES (mepbm
                        Threads::Threads)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,14 +49,17 @@ FOREACH(_testfile ${_testfiles})
   # necessary to run the test. Compile the executable with -Werror
   # to ensure that there are no warnings in either the tests, or the
   # header files these tests #include.
-  ADD_EXECUTABLE(${_testname} EXCLUDE_FROM_ALL ${_testfile})
+  ADD_EXECUTABLE(${_testname}
+                 EXCLUDE_FROM_ALL
+                 ${_testfile}
+                 $<TARGET_OBJECTS:libmepbm>)
   IF(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     TARGET_COMPILE_OPTIONS(${_testname} PRIVATE "/WX")
   ELSE()
     TARGET_COMPILE_OPTIONS(${_testname} PRIVATE "-Werror")
   ENDIF()
   TARGET_LINK_LIBRARIES (${_testname} Threads::Threads)
-  TARGET_LINK_LIBRARIES (${_testname} $<TARGET_OBJECTS:libmepbm>)
+
 
   # Then specify what it means to run a test:
   #


### PR DESCRIPTION
I could compile cmake, but this also makes the old cmake work. Let's stick with this instead -- less disruptions for all the other things you and I have on up/down that have used the old cmake-generated files somewhere in their internal files.