### PR TITLE
Made particle size cutoff member variable double instead of int.

### DIFF
--- a/models.cpp
+++ b/models.cpp
@@ -72,7 +72,7 @@ Parameters(std::numeric_limits<double>::signaling_NaN(),
            std::numeric_limits<double>::signaling_NaN(),
            std::numeric_limits<unsigned int>::max(),
            std::numeric_limits<unsigned int>::max(),
-           std::numeric_limits<unsigned int>::max())
+           std::numeric_limits<double>::max())
 {}
 
 
@@ -82,7 +82,7 @@ Models::ThreeStep::Parameters::Parameters(const double k1_value,
                                           const double k3_value,
                                           const unsigned int nucleation_order,
                                           const unsigned int maxsize_value,
-                                          const unsigned int particle_size_cutoff_value)
+                                          const double particle_size_cutoff_value)
 :
   k1 (k1_value),
   k2 (k2_value),
@@ -106,7 +106,7 @@ Parameters(std::numeric_limits<double>::signaling_NaN(),
            std::numeric_limits<double>::signaling_NaN(),
            std::numeric_limits<unsigned int>::max(),
            std::numeric_limits<unsigned int>::max(),
-           std::numeric_limits<unsigned int>::max())
+           std::numeric_limits<double>::max())
 {}
 
            
@@ -119,7 +119,7 @@ Models::ThreeStepAlternative::Parameters::Parameters(const double k_forward_valu
                                                      const double solvent_value,
                                                      const unsigned int nucleation_order,
                                                      const unsigned int maxsize_value,
-                                                     const unsigned int particle_size_cutoff_value)
+                                                     const double particle_size_cutoff_value)
 :
 k_forward (k_forward_value),
   k_backward (k_backward_value),
@@ -143,10 +143,6 @@ Models::ThreeStepAlternative::Parameters::operator += (const Parameters &prm)
   k3 += prm.k3;
   k_forward += prm.k_forward;
   k_backward += prm.k_backward;
-  solvent += prm.solvent;
-  w += prm.w;
-  maxsize += prm.maxsize;
-  n_variables += prm.n_variables;
   particle_size_cutoff += prm.particle_size_cutoff;
 
   return *this;
@@ -162,10 +158,6 @@ Models::ThreeStepAlternative::Parameters::operator -= (const Parameters &prm)
   k3 -= prm.k3;
   k_forward -= prm.k_forward;
   k_backward -= prm.k_backward;
-  solvent -= prm.solvent;
-  w -= prm.w;
-  maxsize -= prm.maxsize;
-  n_variables -= prm.n_variables;
   particle_size_cutoff -= prm.particle_size_cutoff;
 
   return *this;
@@ -180,10 +172,6 @@ Models::ThreeStepAlternative::Parameters::operator /= (const unsigned int n)
   k3 /= n;
   k_forward /= n;
   k_backward /= n;
-  solvent /= n;
-  w /= n;
-  maxsize /= n;
-  n_variables /= n;
   particle_size_cutoff /= n;
 
   return *this;

--- a/models.h
+++ b/models.h
@@ -111,7 +111,8 @@ namespace Models
     class Parameters : public ParametersBase
     {
     public:
-      double k1, k2, k_forward, k_backward, solvent;
+      double k1, k2, k_forward, k_backward;
+      double solvent;
       unsigned int w, maxsize, n_variables;
 
       // default constructor. creates an invalid object
@@ -164,7 +165,13 @@ namespace Models
     {
     public:
       double k1, k2, k3;
-      unsigned int w, maxsize, n_variables, particle_size_cutoff;
+      unsigned int w, maxsize, n_variables;
+      // physically, this should be an integer, but this
+      // is a variable parameter and if we wish to perform
+      // statistics (e.g. compute a mean value from a 
+      // probability distribution) we need this to be stored
+      // as a double.
+      double particle_size_cutoff;
 
       // default constructor. creates an invalid object
       Parameters();
@@ -175,7 +182,7 @@ namespace Models
              const double k3_value,
              const unsigned int nucleation_order,
              const unsigned int maxsize_value,
-             const unsigned int particle_size_cutoff_value);
+             const double particle_size_cutoff_value);
 
       friend
       std::ostream &
@@ -238,8 +245,15 @@ namespace Models
     class Parameters : public ParametersBase
     {
     public:
-      double k1, k2, k3, k_forward, k_backward, solvent;
-      unsigned int w, maxsize, n_variables, particle_size_cutoff;
+      double k1, k2, k3, k_forward, k_backward;
+      double solvent;
+      unsigned int w, maxsize, n_variables;
+      // physically, this should be an integer, but this
+      // is a variable parameter and if we wish to perform
+      // statistics (e.g. compute a mean value from a 
+      // probability distribution) we need this to be stored
+      // as a double.
+      double particle_size_cutoff;
 
       // default constructor. creates an invalid object
       Parameters();
@@ -253,7 +267,7 @@ namespace Models
              const double solvent_value,
              const unsigned int nucleation_order,
              const unsigned int maxsize_value,
-             const unsigned int particle_size_cutoff_value);
+             const double particle_size_cutoff_value);
 
       // Add and subtract two sets of parameters, treating them as
       // simple tuples of numbers


### PR DESCRIPTION
I made the particle size cutoff double instead of int. I was hoping to also make `solvent`, `w`, `maxsize`, and `n_variables` be const members within the models classes, but I am getting compiler errors:

`/cygdrive/c/p/repositories/mepbm/models.h:245:11: note: ‘Models::ThreeStepAlternative::Parameters& Models::ThreeStepAlternative::Parameters::operator=(const Models::ThreeStepAlternative::Parameters&)’ is implicitly deleted because the default definition would be ill-formed:
`
and
`
/cygdrive/c/p/repositories/mepbm/models.h:245:11: error: non-static const member ‘const double Models::ThreeStepAlternative::Parameters::solvent’, can’t use default assignment operator
`