### PR TITLE
Compute the mean value.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 
 #include <sampleflow/producers/metropolis_hastings.h>
 #include <sampleflow/consumers/stream_output.h>
+#include <sampleflow/consumers/mean_value.h>
 
 
 // The data type that describes the samples we want to draw from some
@@ -158,10 +159,20 @@ int main()
   SampleFlow::Producers::MetropolisHastings<SampleType> mh_sampler;
   SampleFlow::Consumers::StreamOutput<SampleType> stream_output (samples);
   stream_output.connect_to_producer (mh_sampler);
+
+  SampleFlow::Consumers::MeanValue<SampleType> mean_value;
+  mean_value.connect_to_producer (mh_sampler);
   
   // Sample from the given distribution
+  const unsigned int n_samples = 10;
   mh_sampler.sample (starting_guess,
                      &log_probability,
                      &perturb,
-                     10);
+                     n_samples);
+
+  // Output the statistics we have computed in the process of sampling
+  // everything
+  std::cout << "Mean value of all samples:\n"
+            << mean_value.get()
+            << std::endl;
 }


### PR DESCRIPTION
Here you go!

The samples I get are like this:
```
kf=0.036, kb=72700, k1=64500, k2=16300, k3=5560, w=3, maxsize=2500, n_variables=2501, particle_size_cutoff=274
kf=0.036, kb=72316.3, k1=65444.4, k2=15676.8, k3=6545.76, w=3, maxsize=2500, n_variables=2501, particle_size_cutoff=266
kf=0.036, kb=73309.3, k1=74798.3, k2=16128.4, k3=7507.98, w=3, maxsize=2500, n_variables=2501, particle_size_cutoff=275
kf=0.036, kb=73309.3, k1=74798.3, k2=16128.4, k3=7507.98, w=3, maxsize=2500, n_variables=2501, particle_size_cutoff=275
kf=0.036, kb=73309.3, k1=74798.3, k2=16128.4, k3=7507.98, w=3, maxsize=2500, n_variables=2501, particle_size_cutoff=275
kf=0.036, kb=73905.1, k1=72024.2, k2=15552.3, k3=7870.7, w=3, maxsize=2500, n_variables=2501, particle_size_cutoff=285
kf=0.036, kb=73905.1, k1=72024.2, k2=15552.3, k3=7870.7, w=3, maxsize=2500, n_variables=2501, particle_size_cutoff=285
kf=0.036, kb=73905.1, k1=72024.2, k2=15552.3, k3=7870.7, w=3, maxsize=2500, n_variables=2501, particle_size_cutoff=285
kf=0.036, kb=74650, k1=65006.5, k2=16540.4, k3=8514.51, w=3, maxsize=2500, n_variables=2501, particle_size_cutoff=288
kf=0.036, kb=73900.3, k1=70281.5, k2=16521.6, k3=8841.72, w=3, maxsize=2500, n_variables=2501, particle_size_cutoff=284
```
and it prints this for the mean:
```
kf=0.036, kb=73521, k1=70570, k2=16008.1, k3=7559.8, w=4294967295, maxsize=4294967295, n_variables=4, particle_size_cutoff=279.2
```

Since you don't vary the `const` parameters in the `Parameters` structure, you might as well remove outputting them in `operator<<` -- there is nothing for us to learn from seeing their values.

On my system, this runs for 3min26s, so pretty much exactly 20s per sample. (You get to see the run time if you run the executable via `time ./mepbm`.) You can make your runs faster if you do
```
cmake -DCMAKE_BUILD_TYPE=RELEASE .
make clean
make
```
Choosing the `RELEASE` build type enables compiler optimizations that aren't on by default. For me, the `RELEASE` build runs in about 2/3 the time of the default build.

It isn't exceedingly difficult to add histograms and covariance matrices to this, but how about you first run this overnight and we just look at the samples you have. The night has ~8 hours, so try whether you can reproduce the samples above and then pick something like 1500 samples?