### PR TITLE
Also compute the acceptance ratio of the sampler.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -11,6 +11,7 @@
 #include <sampleflow/consumers/stream_output.h>
 #include <sampleflow/consumers/mean_value.h>
 #include <sampleflow/consumers/histogram.h>
+#include <sampleflow/consumers/acceptance_ratio.h>
 
 
 // The data type that describes the samples we want to draw from some
@@ -165,6 +166,9 @@ int main()
   SampleFlow::Consumers::MeanValue<SampleType> mean_value;
   mean_value.connect_to_producer (mh_sampler);
 
+  SampleFlow::Consumers::AcceptanceRatio<SampleType> acceptance_ratio;
+  acceptance_ratio.connect_to_producer (mh_sampler);
+  
 
   SampleFlow::Filters::Conversion<SampleType,double>
     extract_k1 ([](const SampleType &prm) { return prm.k1; });
@@ -188,6 +192,9 @@ int main()
   // everything
   std::cout << "Mean value of all samples:\n"
             << mean_value.get()
+            << std::endl;
+  std::cout << "MH acceptance ratio: "
+            << acceptance_ratio.get()
             << std::endl;
 
   // Now also output the histograms for all parameters:

--- a/models.cpp
+++ b/models.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <valarray>
 #include <stdexcept>
+#include <cassert>
 #include "models.h"
 
 
@@ -280,6 +281,28 @@ Models::ThreeStep::Parameters::operator /= (const unsigned int n)
   particle_size_cutoff /= n;
 
   return *this;
+}
+
+
+
+bool
+Models::ThreeStepAlternative::Parameters::operator == (const Parameters &prm) const
+{
+  // We'd be in trouble if we tried to compare two objects for which
+  // the 'const' variables are different -- that would mean comparing
+  // models of completely different kind.
+  assert (solvent == prm.solvent);
+  assert (w == prm.w);
+  assert (maxsize == prm.maxsize);
+  assert (n_variables == prm.n_variables);
+  
+  return
+    ((k1 == prm.k1) &&
+     (k2 == prm.k2) &&
+     (k3 == prm.k3) &&
+     (k_forward == prm.k_forward) &&
+     (k_backward == prm.k_backward) &&
+     (particle_size_cutoff == prm.particle_size_cutoff));
 }
 
 

--- a/models.h
+++ b/models.h
@@ -336,6 +336,9 @@ namespace Models
       // Setting parameters equal, skipping the const members
       Parameters operator = (const Parameters &prm);
       
+      // Compare two parameter objects
+      bool operator == (const Parameters &prm) const;
+      
       // Add and subtract two sets of parameters, treating them as
       // simple tuples of numbers
       Parameters operator += (const Parameters &prm);


### PR DESCRIPTION
Here's a quick way to compute the acceptance ratio of the sampling process. You should shoot for around 25-30% acceptance ratio on larger numbers of samples. If you choose the proposal distribution radius too large, you'll have a pretty low acceptance ratio. If you choose the radius too small, you'll have a pretty high acceptance ratio. Shooting for 25-30% gives you a way to judge whether you're in the right ballpark with your search radius.

It's probably going to be difficult to play with this if it takes 20 seconds per sample. You might want to tune this ratio by making the time step larger by a factor of 10 or 50, so you can get a substantial number of samples within a few minutes. You'll need a few 100 to get a good picture of the acceptance ratio. Once you've got your search radius sorted out, switch back to the original time step choice.