### PR TITLE
Some changes to work with SampleFlow

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <limits>
 #include <vector>
+#include <memory>
 #include "models.h"
 #include "histogram.h"
 #include "statistics.h"
@@ -187,19 +188,26 @@ std::vector<double> Sample::return_times() const
 // Here we implement a Four-Step Model
 Model::Model Sample::return_model() const
 {
-  Model::TermolecularNucleation nucleation(const_parameters.A_index, const_parameters.As_index,
-                                           const_parameters.ligand_index, const_parameters.min_size,
-                                           const_parameters.kf, kb, k1, const_parameters.solvent);
-  Model::Growth small_growth(const_parameters.A_index, const_parameters.min_size, cutoff,
-                             const_parameters.max_size, const_parameters.ligand_index,
-                             const_parameters.conserved_size, k2);
-  Model::Growth large_growth(const_parameters.A_index, cutoff+1, const_parameters.max_size,
-                             const_parameters.max_size, const_parameters.ligand_index,
-                             const_parameters.conserved_size, k3);
-  Model::Agglomeration agglomeration(const_parameters.min_size, cutoff,
-                                     const_parameters.min_size, cutoff,
-                                     const_parameters.max_size, const_parameters.conserved_size,
-                                     k4);
+  std::shared_ptr<Model::RightHandSideContribution> nucleation =
+    std::make_shared<Model::TermolecularNucleation>(const_parameters.A_index, const_parameters.As_index,
+                                                    const_parameters.ligand_index, const_parameters.min_size,
+                                                    const_parameters.kf, kb, k1, const_parameters.solvent);
+
+  std::shared_ptr<Model::RightHandSideContribution> small_growth =
+    std::make_shared<Model::Growth>(const_parameters.A_index, const_parameters.min_size, cutoff,
+                                    const_parameters.max_size, const_parameters.ligand_index,
+                                    const_parameters.conserved_size, k2);
+
+  std::shared_ptr<Model::RightHandSideContribution> large_growth =
+    std::make_shared<Model::Growth>(const_parameters.A_index, cutoff+1, const_parameters.max_size,
+                                    const_parameters.max_size, const_parameters.ligand_index,
+                                    const_parameters.conserved_size, k3);
+
+  std::shared_ptr<Model::RightHandSideContribution> agglomeration =
+  std::make_shared<Model::Agglomeration>(const_parameters.min_size, cutoff,
+                                         const_parameters.min_size, cutoff,
+                                         const_parameters.max_size, const_parameters.conserved_size,
+                                         k4);
 
   Model::Model model(const_parameters.min_size, const_parameters.max_size);
   model.add_rhs_contribution(nucleation);

--- a/main.cpp
+++ b/main.cpp
@@ -1,8 +1,6 @@
 #include <iostream>
 #include <fstream>
 #include <limits>
-#include <random>
-#include <functional>
 #include <vector>
 #include "models.h"
 #include "histogram.h"
@@ -13,145 +11,295 @@
 #include <sampleflow/filters/conversion.h>
 #include <sampleflow/consumers/stream_output.h>
 #include <sampleflow/consumers/mean_value.h>
-#include <sampleflow/consumers/histogram.h>
 #include <sampleflow/consumers/acceptance_ratio.h>
 
-/*
-// The data type that describes the samples we want to draw from some
-// probability distribution.
-using SampleType = Models::TwoStepAlternative::Parameters;
+
 
 // A data type we will use to convert samples to whenever we want to
 // do arithmetic with them, such as if we want to compute mean values,
 // covariances, etc.
 using VectorType = std::valarray<double>;
 
+/*
+ * Create an object which holds all of the constant information for the mechanism
+ */
 
-
-// A function that given a SampleType object (i.e., a set of model
-// parameters) computes the corresponding likelihood
-double log_likelihood (const SampleType &prm)
+class ConstantData
 {
-  // data used for likelihood
-  const Data::PomData raw_data;
-  const std::vector<std::valarray<double>> data_atoms = { std::pow(raw_data.tem_diam_time1/0.3000805, 3),
-                                                          std::pow(raw_data.tem_diam_time2/0.3000805, 3),
-                                                          std::pow(raw_data.tem_diam_time3/0.3000805, 3),
-                                                          std::pow(raw_data.tem_diam_time4/0.3000805, 3)};
+public:
+  ConstantData();
 
-  // create model
-  Models::TwoStepAlternative model;
+  unsigned int min_size = 3;
+  unsigned int max_size = 2500;
+  unsigned int conserved_size = 1;
 
-  // set up initial conditions and times for the ODE solution
-  std::valarray<double> initialCondition(0.0,prm.n_variables);
-  initialCondition[0] = 0.0012;
-  const std::vector<double> times = {0,
-                                     raw_data.tem_time1,
-                                     raw_data.tem_time2,
-                                     raw_data.tem_time3,
-                                     raw_data.tem_time4};
+  unsigned int A_index = 0;
+  unsigned int As_index = 1;
+  unsigned int ligand_index = 2;
 
+  double solvent = 11.3;
+  double kf = 3.6e-2;
 
-  // define parameters for the histogram
-  const Histograms::Parameters histogramParameters(25, model.getSmallestParticleSize(prm), model.getLargestParticleSize(prm));
+  Data::PomData data_diameter;
+  std::vector< std::vector<double> > data_size;
+  std::vector<double> times;
 
-  // calculate log likelihood and return it
-  return Statistics::log_likelihood(data_atoms, times, model, prm, initialCondition, histogramParameters);
+  // { kb, k1, k2, k3, k4 }
+  std::vector<double> lower_bounds = { 1000., 4800., 10., 10., 10.};
+  std::vector<double> upper_bounds = { 2.e6, 8.e7, 8.5e5, 2.5e5, 2.5e5};
 
+  unsigned int lower_bound_cutoff = 10;
+  unsigned int upper_bound_cutoff = 2000;
+
+  // { kb, k1, k2, k3, k4 }
+  std::vector<double> perturbation_magnitude = { 1.e4, 5.e4, 5.e4, 4.e3, 5.e2 };
+  int perturbation_magnitude_cutoff = 30;
+
+  std::vector<double> initial_condition;
+
+  unsigned int hist_bins = 25;
+
+};
+
+ConstantData::ConstantData()
+{
+  const std::vector<std::vector<double>> data_diam = {data_diameter.tem_diam_time1, data_diameter.tem_diam_time2,
+                                                      data_diameter.tem_diam_time3, data_diameter.tem_diam_time4};
+  for (const auto& vec : data_diam)
+  {
+    std::vector<double> tmp;
+    for (auto diam : vec)
+    {
+      tmp.push_back(std::pow(diam/0.3000805, 3));
+    }
+    data_size.push_back(tmp);
+  }
+
+  times = {0., data_diameter.tem_time1, data_diameter.tem_time2, data_diameter.tem_time3, data_diameter.tem_time4};
+
+  std::vector<double> zeros(max_size+1, 0.);
+  initial_condition = zeros;
+  initial_condition[0] = 0.0012;
 }
 
 
 
-// A function that given three SampleType objects (i.e., one for maximum allowable parameters,
-// one for minimum allowable parameters, and one for the current set of parameters) computes
-// the corresponding prior.
-double log_prior (const SampleType &prm)
+/*
+ * Create an object of type Sample which holds all of the variable information for the mechanism.
+ * This object must be able to interface with SampleFlow, so it must have the following functionality:
+ *
+ * Member variables:
+ *  Whichever variables you want to vary as samples are collected must be indicated here.
+ *  A ConstantData object as defined above.
+ *
+ * Member functions:
+ *  std::vector< std::vector<double> > return_data()
+ *      -- a collection of vectors corresponding to collected data which gives particle size for each data.
+ *  std::vector<double> return_times()
+ *      -- the first element is intended to be time=0 and the remaining times should correspond to when
+ *      the return_data() entries were collected.
+ *  Model::Model return_model()
+ *      -- an object describing the right hand side of the system of differential equations
+ *  std::vector<double> return_initial_condition()
+ *      -- a vector giving the concentrations of the tracked chemical species at time = 0.
+ *  Histograms::Parameters return_histogram_parameters()
+ *      -- an object describing the to bin together particle sizes to compare the data and simulation results.
+ *  bool within_bounds()
+ *      -- The intent of this function is to compare the current state of the parameters being sampled and
+ *      compare to a pre-determined domain for those parameters.
+ *      If any parameter lies outside of its allowed interval, return false. Otherwise, return true.
+ *  Sample perturb()
+ *      -- Generates random perturbations of the parameters in the sample and returns a new object reflecting
+ *      the randomly chosen new parameters.
+ *  double perturb_ratio()
+ *      -- Computes the ratio of probabilities parameter->new_parameters / new_parameter->parameters
+ *
+ *  Operators:
+ *    Sample operator = (const Sample &sample);
+ *      -- A rule for setting parameters equal to one another.
+ *    operator std::valarray<double> () const;
+ *      -- A rule for turning a sample into a vector of the parameters.
+ *      Essentially just populating a valarray with the appropriate values.
+ *    friend std::ostream & operator<< (std::ostream &out, const Sample &sample)
+ *      -- A rule for what to output to a line of an external file in a way that's understood as a complete sample.
+ */
+class Sample
 {
-  // FIXME: It would be nice if this could automatically detect the member variables
-  // we would like to optimize
-  if (
-      prm.k_backward < 1000. || prm.k_backward > 2000000.
-      || prm.k1 < 4800. || prm.k1 > 8e+07
-      || prm.k2 < 10. || prm.k2 > 850000.
-  )
-    return -std::numeric_limits<double>::max();
+public:
+  double kb, k1, k2, k3, k4;
+  unsigned int cutoff;
+
+  // Default constructor makes an invalid object
+  Sample();
+  Sample(double kb, double k1, double k2, double k3, double k4, unsigned int cutoff);
+
+  std::vector< std::vector<double> > return_data() const;
+  std::vector<double> return_times() const;
+  Model::Model return_model() const;
+  std::vector<double> return_initial_condition() const;
+  Histograms::Parameters return_histogram_parameters() const;
+  bool within_bounds() const;
+  Sample perturb() const;
+  double perturb_ratio() const;
+
+  Sample operator = (const Sample &sample);
+  operator std::valarray<double> () const;
+
+  friend std::ostream & operator<< (std::ostream &out, const Sample &sample);
+
+private:
+  ConstantData const_parameters;
+};
+
+
+
+Sample::Sample(double kb, double k1, double k2, double k3, double k4, unsigned int cutoff)
+  : kb(kb), k1(k1), k2(k2), k3(k3), k4(k4), cutoff(cutoff)
+{}
+
+
+
+Sample::Sample()
+  : Sample(std::numeric_limits<double>::signaling_NaN(),
+           std::numeric_limits<double>::signaling_NaN(),
+           std::numeric_limits<double>::signaling_NaN(),
+           std::numeric_limits<double>::signaling_NaN(),
+           std::numeric_limits<double>::signaling_NaN(),
+           static_cast<unsigned int>(-1))
+{}
+
+
+
+std::vector<std::vector<double>> Sample::return_data() const
+{
+  return const_parameters.data_size;
+}
+
+
+
+std::vector<double> Sample::return_times() const
+{
+  return const_parameters.times;
+}
+
+
+
+// Here we implement a Four-Step Model
+Model::Model Sample::return_model() const
+{
+  Model::TermolecularNucleation nucleation(const_parameters.A_index, const_parameters.As_index,
+                                           const_parameters.ligand_index, const_parameters.min_size,
+                                           const_parameters.kf, kb, k1, const_parameters.solvent);
+  Model::Growth small_growth(const_parameters.A_index, const_parameters.min_size, cutoff,
+                             const_parameters.max_size, const_parameters.ligand_index,
+                             const_parameters.conserved_size, k2);
+  Model::Growth large_growth(const_parameters.A_index, cutoff+1, const_parameters.max_size,
+                             const_parameters.max_size, const_parameters.ligand_index,
+                             const_parameters.conserved_size, k3);
+  Model::Agglomeration agglomeration(const_parameters.min_size, cutoff,
+                                     const_parameters.min_size, cutoff,
+                                     const_parameters.max_size, const_parameters.conserved_size,
+                                     k4);
+
+  Model::Model model(const_parameters.min_size, const_parameters.max_size);
+  model.add_rhs_contribution(nucleation);
+  model.add_rhs_contribution(small_growth);
+  model.add_rhs_contribution(large_growth);
+  model.add_rhs_contribution(agglomeration);
+
+  return model;
+}
+
+
+
+std::vector<double> Sample::return_initial_condition() const
+{
+  return const_parameters.initial_condition;
+}
+
+
+
+Histograms::Parameters Sample::return_histogram_parameters() const
+{
+  Histograms::Parameters hist_parameters(const_parameters.hist_bins, const_parameters.min_size,
+                                         const_parameters.max_size);
+  return hist_parameters;
+}
+
+
+
+bool Sample::within_bounds() const
+{
+  if ( kb < const_parameters.lower_bounds[0] || kb > const_parameters.upper_bounds[0]
+       || k1 < const_parameters.lower_bounds[1] || k1 > const_parameters.upper_bounds[1]
+       || k2 < const_parameters.lower_bounds[2] || k2 > const_parameters.upper_bounds[2]
+       || k3 < const_parameters.lower_bounds[3] || k3 > const_parameters.upper_bounds[3]
+       || k4 < const_parameters.lower_bounds[4] || k4 > const_parameters.upper_bounds[4]
+       || cutoff < const_parameters.lower_bound_cutoff || cutoff > const_parameters.upper_bound_cutoff)
+    return false;
   else
-    return 0.;
+    return true;
 }
 
 
 
-double log_probability (const SampleType &prm)
+Sample Sample::perturb() const
 {
-  const double logPrior = log_prior(prm);
+  double new_kb = kb + Statistics::rand_btwn_double(-const_parameters.perturbation_magnitude[0],
+                                                    const_parameters.perturbation_magnitude[0]);
+  double new_k1 = k1 + Statistics::rand_btwn_double(-const_parameters.perturbation_magnitude[1],
+                                                    const_parameters.perturbation_magnitude[1]);
+  double new_k2 = k2 + Statistics::rand_btwn_double(-const_parameters.perturbation_magnitude[2],
+                                                    const_parameters.perturbation_magnitude[2]);
+  double new_k3 = k3 + Statistics::rand_btwn_double(-const_parameters.perturbation_magnitude[3],
+                                                    const_parameters.perturbation_magnitude[3]);
+  double new_k4 = k4 + Statistics::rand_btwn_double(-const_parameters.perturbation_magnitude[4],
+                                                    const_parameters.perturbation_magnitude[4]);
+  unsigned int new_cutoff = cutoff + Statistics::rand_btwn_int(-const_parameters.perturbation_magnitude_cutoff,
+                                                               const_parameters.perturbation_magnitude_cutoff);
 
-  // If the prior probability for a sample is zero, multiplication
-  // with the (expensive to compute) likelihood isn't going to change
-  // that. So just return what we already got.
-  if (logPrior == -std::numeric_limits<double>::max())
-    return logPrior;
-  
-  else
-  // Return the probability=likelihood*prior, except of course we're
-  // only dealing with logarithms.
-    return log_likelihood(prm) + logPrior;
+  Sample new_sample(new_kb, new_k1, new_k2, new_k3, new_k4, new_cutoff);
+  return new_sample;
 }
 
 
 
-// A function given two real numbers returns a random number
-// between those numbers based on a uniform distribution
-double rand_btwn_double (const double small_num, const double big_num)
+double Sample::perturb_ratio() const
 {
-  static std::mt19937 gen;
-  std::uniform_real_distribution<> unif(small_num,big_num);
-
-  return unif(gen);
+  return 1.;
 }
 
 
 
-// A function given two integers returns a random number
-// between those numbers based on a uniform distribution
-int rand_btwn_int (const int small_num, const int big_num)
+Sample Sample::operator=(const Sample &sample)
 {
-  static std::mt19937 gen;
-  std::uniform_int_distribution<> unif(small_num,big_num);
-
-  return unif(gen);
+  return Sample(sample.kb, sample.k1, sample.k2, sample.k3, sample.k4, sample.cutoff);
 }
 
 
 
-// A function given a SampleType object returns a SampleType
-// object whose member variables have been randomly perturbed
-// along with the ratio of the probabilities of prm->new_prm /
-// new_prm->prm
-std::pair<SampleType,double> perturb (const SampleType &prm)
+Sample::operator std::valarray<double>() const
 {
-  // perturb each non-constant parameter with a uniform distribution
-  double new_k_backward = prm.k_backward + rand_btwn_double(-1.e4, 1.e4);
-  double new_k1 = prm.k1 + rand_btwn_double(-5.e4, 5.e4);
-  double new_k2 = prm.k2 + rand_btwn_double(-5.e3, 5.e3);
-
-  SampleType new_prm(prm.k_forward,
-                     new_k_backward,
-                     new_k1,
-                     new_k2,
-                     prm.solvent,
-                     prm.w,
-                     prm.maxsize);
-
-  return {new_prm, 1.};
+  return { kb, k1, k2, k3, k4, static_cast<double>(cutoff)};
 }
 
-*/
+std::ostream &operator<<(std::ostream &out, const Sample &sample)
+{
+  out << sample.kb << ", "
+      << sample.k1 << ", "
+      << sample.k2 << ", "
+      << sample.k3 << ", "
+      << sample.k4 << ", "
+      << sample.cutoff ;
+  return out;
+}
+
 
 int main(int argc, char **argv)
 {
-  /*
-  const SampleType
-    starting_guess (3.6e-2, 7.27e4, 4.80e4, 3.99e4, 11.3, 3, 2500);
+
+  // Create sample with initial values for parameters
+  Sample starting_guess(7.27e4, 6.4e4, 1.61e4, 5.45e4, 1.2e1, 265);
 
   std::ofstream samples ("samples"
                          +
@@ -161,12 +309,12 @@ int main(int argc, char **argv)
                          +
                          ".txt");
 
-  SampleFlow::Producers::MetropolisHastings<SampleType> mh_sampler;
+  SampleFlow::Producers::MetropolisHastings<Sample> mh_sampler;
   
-  SampleFlow::Consumers::StreamOutput<SampleType> stream_output (samples);
+  SampleFlow::Consumers::StreamOutput<Sample> stream_output (samples);
   stream_output.connect_to_producer (mh_sampler);
 
-  SampleFlow::Filters::Conversion<SampleType,VectorType> convert_to_vector;
+  SampleFlow::Filters::Conversion<Sample,VectorType> convert_to_vector;
   convert_to_vector.connect_to_producer (mh_sampler);
   
   SampleFlow::Consumers::MeanValue<VectorType> mean_value;
@@ -174,19 +322,7 @@ int main(int argc, char **argv)
 
   SampleFlow::Consumers::AcceptanceRatio<VectorType> acceptance_ratio;
   acceptance_ratio.connect_to_producer (convert_to_vector);
-  
 
-  SampleFlow::Filters::Conversion<SampleType,double>
-    extract_k1 ([](const SampleType &prm) { return prm.k1; });
-  extract_k1.connect_to_producer (mh_sampler);
-
-  const double k1_min = 0;
-  const double k1_max = 3e5;
-  const unsigned int n_bins = 100;
-  SampleFlow::Consumers::Histogram<double> histogram_k1 (k1_min, k1_max, n_bins);
-  histogram_k1.connect_to_producer (extract_k1);
-  
-  
   // Sample from the given distribution.
   //
   // If an argument was given on the command line,
@@ -198,8 +334,8 @@ int main(int argc, char **argv)
        std::uint_fast32_t());
   const unsigned int n_samples = 2;
   mh_sampler.sample (starting_guess,
-                     &log_probability,
-                     &perturb,
+                     &Statistics::log_probability<Sample>,
+                     &Statistics::perturb<Sample>,
                      n_samples,
                      random_seed);
 
@@ -208,13 +344,8 @@ int main(int argc, char **argv)
   std::cout << "Mean value of all samples:\n";
   for (auto x : mean_value.get())
     std::cout << x << ' ';
-  std::cout << std::endl;
-  std::cout << "MH acceptance ratio: "
-            << acceptance_ratio.get()
-            << std::endl;
-
-  // Now also output the histograms for all parameters:
-  histogram_k1.write_gnuplot (std::ofstream("histogram_k1.txt"));
-   */
-  std::cout << "Yippee!" << std::endl;
+    std::cout << std::endl;
+    std::cout << "MH acceptance ratio: "
+              << acceptance_ratio.get()
+              << std::endl;
 }

--- a/models.cpp
+++ b/models.cpp
@@ -219,9 +219,9 @@ void Model::Model::operator()(const StateVector &x, StateVector &rhs, double  /*
     rh = 0.;
   }
 
-  for (unsigned int i = 0; i < rhs_contributions.size(); ++i)
+  for (auto & rhs_contribution : rhs_contributions)
   {
-    rhs_contributions[i]->add_contribution_to_rhs(x, rhs);
+    rhs_contribution->add_contribution_to_rhs(x, rhs);
   }
 }
 

--- a/statistics.cpp
+++ b/statistics.cpp
@@ -1,11 +1,12 @@
 #include <valarray>
 #include <cmath>
 #include <vector>
+#include <random>
 #include "models.h"
 #include "histogram.h"
 #include "statistics.h"
 #include <boost/numeric/odeint.hpp>
-#include <iostream>
+
 
 
 using VectorType = std::vector<double>;
@@ -26,9 +27,9 @@ double Statistics::log_likelihood(const VectorType& data,
   // Step 2 -- Turn distribution into a histogram
     // Step 2a -- Normalize distribution to create probability mass function (pmf)
     double norm = 0.;
-    for (unsigned int i=0; i<distribution.size(); ++i)
+    for (double concentration : distribution)
     {
-      norm += distribution[i];
+      norm += concentration;
     }
 
     VectorType pmf(distribution.size());
@@ -110,4 +111,24 @@ double Statistics::log_likelihood(const std::vector<VectorType>& data,
     }
 
   return likelihood;
+}
+
+
+
+double Statistics::rand_btwn_double (const double small_num, const double big_num)
+{
+  static std::mt19937 gen;
+  std::uniform_real_distribution<> unif(small_num,big_num);
+
+  return unif(gen);
+}
+
+
+
+int Statistics::rand_btwn_int (const int small_num, const int big_num)
+{
+  static std::mt19937 gen;
+  std::uniform_int_distribution<> unif(small_num,big_num);
+
+  return unif(gen);
 }


### PR DESCRIPTION
Moved probability functions that interface with SampleFlow to the Statistics namespace. Started making a spaghetti version of how I would like the user to interact with this program.

I do have one issue that I'm not sure how to fix. In main.cpp I have a function Sample::return_model() where I create the right-hand side contributions and add them to the model. The issue seems to be that since the Model::Model object takes in pointers to the right-hand side contributions, there is a memory issue since the contributions made are destroyed upon exiting the return_model() scope so the ODE solver cannot see them when it needs to form the right-hand side. How I have the code now is (an admittedly spaghetti version) how I am thinking of a user interacting with the program, so I don't know how to resolve this without drastically changing how main.cpp looks at the moment -- or maybe I have no choice?