### PR TITLE
Need to seed the rng for perturb.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -371,6 +371,7 @@ int main(int argc, char **argv)
   const unsigned int n_samples = 5;
 
   std::mt19937 rng;
+  rng.seed(random_seed);
   mh_sampler.sample (starting_guess,
                      &Statistics::log_probability<Sample,4>,
                      [&rng](const Sample &s)


### PR DESCRIPTION
Previously, a random was created but it was only fed into the mh sampler which used that seed when deciding to accept a sample or not. We need to also seed the rng used in the perturb function; otherwise, all perturbations will start from the default seed and have similar results frequently as I had previously observed.