### PR TITLE
Adjust how Eigen is found

### DIFF
--- a/.github/workflows/mepbm.yml
+++ b/.github/workflows/mepbm.yml
@@ -21,12 +21,13 @@ jobs:
         git clone https://github.com/bangerth/SampleFlow.git
         git clone https://gitlab.com/libeigen/eigen.git
         mkdir ./eigen/build
+        mkdir ./eigen/install
         cd ./eigen/build
-        cmake ../
+        cmake ../ -DCMAKE_INSTALL_PREFIX=../install
         sudo make install
         cd ../../
     - name: cmake
-      run: cmake -DSAMPLEFLOW_DIR="$PWD/SampleFlow" -DCMAKE_BUILD_TYPE=release .
+      run: cmake -DSAMPLEFLOW_DIR="$PWD/SampleFlow" -DEIGEN_DIR="$PWD/eigen" -DCMAKE_BUILD_TYPE=release .
     - name: build
       run: make
     - name: ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,24 @@ SET (CMAKE_CXX_EXTENSIONS OFF)
 # Also make sure we link with the threads library in question
 FIND_PACKAGE (Threads)
 
-# Link with Eigen library
-FIND_PACKAGE (Eigen3 3.3 REQUIRED NO_MODULE
-			  HINTS ${EIGEN_DIR} $ENV{EIGEN_DIR})
 
-IF(${Eigen3_FOUND})
-	MESSAGE(STATUS "Found Eigen at '${Eigen3_DIR}'")
+#########################################
+### Find the Eigen library
+FIND_PATH(_eigen_include_dir
+          NAMES eigen3/Eigen/Dense
+          HINTS ${EIGEN_DIR}/install/include)
+IF ("${_eigen_include_dir}" STREQUAL "_eigen_include_dir-NOTFOUND")
+  MESSAGE(FATAL_ERROR
+          "The Eigen library was not found. You have to specify a path "
+          "to that library by setting the EIGEN_DIR environment variable, "
+          "or passing '-DEIGEN_DIR=...' as an argument to 'cmake'.")
+ELSE()
+  MESSAGE(STATUS "Found EIGEN headers at ${_eigen_include_dir}")
+  INCLUDE_DIRECTORIES(${_eigen_include_dir})
 ENDIF()
 
+
+#########################################
 # Find include files in the current directory
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -60,8 +70,7 @@ ADD_EXECUTABLE(mepbm
                main.cpp
                $<TARGET_OBJECTS:libmepbm>)
 TARGET_LINK_LIBRARIES (mepbm
-                       Threads::Threads
-                       Eigen3::Eigen)
+                       Threads::Threads)
 
 
 #########################################


### PR DESCRIPTION
Previously, this depended on installing Eigen to /usr/local/include which causes issues if using a computer you do not have sudo privilege for. Now you can provide a location /my_eigen_location/ such that Eigen is installed to the location /my_eigen_location/install/