### PR TITLE
Let EIGEN_DIR specify the whole path to where eigen is installed.

### DIFF
--- a/.github/workflows/mepbm.yml
+++ b/.github/workflows/mepbm.yml
@@ -27,7 +27,7 @@ jobs:
         sudo make install
         cd ../../
     - name: cmake
-      run: cmake -DSAMPLEFLOW_DIR="$PWD/SampleFlow" -DEIGEN_DIR="$PWD/eigen" -DCMAKE_BUILD_TYPE=release .
+      run: cmake -DSAMPLEFLOW_DIR="$PWD/SampleFlow" -DEIGEN_DIR="$PWD/eigen/install" -DCMAKE_BUILD_TYPE=release .
     - name: build
       run: make
     - name: ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ FIND_PACKAGE (Threads)
 ### Find the Eigen library
 FIND_PATH(_eigen_include_dir
           NAMES eigen3/Eigen/Dense
-          HINTS ${EIGEN_DIR}/install/include)
+          HINTS ${EIGEN_DIR}/include)
 IF ("${_eigen_include_dir}" STREQUAL "_eigen_include_dir-NOTFOUND")
   MESSAGE(FATAL_ERROR
           "The Eigen library was not found. You have to specify a path "


### PR DESCRIPTION
By convention, this is the actual directory, without making assumptions about any further
subdirectories that users may name however they so choose. Right now, the final
subdirectory needs to be called 'install/', without giving those who installed the
package a choice in this matter.