### PR TITLE
Negative

### DIFF
--- a/ode_solver.h
+++ b/ode_solver.h
@@ -11,22 +11,6 @@ namespace ODE
 {
   /***************** Classes -- Implementations in .cpp *****************/
 
-  // FIXME: This is a placeholder for the moment. Eventually I will integrate this class
-  // FIXME: with the objects in models.h but that first requires a bunch of things to be
-  // FIXME: converted from Boost data types to Eigen data types.
-  /*
-  class OdeSystem
-  {
-  public:
-    Eigen::VectorXd compute_rhs(double t, const Eigen::VectorXd &x) const;
-
-    Eigen::MatrixXd compute_jacobian(double t, const Eigen::VectorXd &x) const;
-
-    Eigen::PartialPivLU<Eigen::MatrixXd> jacobian_solver;
-  };
-
-*/
-
   /*
    * Base class for ODE time stepper
    */

--- a/tests/log_likelihood_negative.cc
+++ b/tests/log_likelihood_negative.cc
@@ -1,0 +1,24 @@
+#include <iostream>
+#include "histogram.h"
+#include "statistics.h"
+
+
+
+int main()
+{
+  // create dummy data
+  std::vector<double> data = {3,4,5,6,4,5};
+
+  // create dummy distribution
+  std::vector<double> sizes = {3, 4, 5, 6};
+  std::vector<double> distr = {1, -1, 3, 4};
+
+  // create histogram parameters
+  Histograms::Parameters hist_prm(4, 3, 6);
+
+  // calculate log likelihood
+  double likelihood = Statistics::log_likelihood(data, distr, sizes, hist_prm);
+
+  // print result
+  std::cout << "log likelihood: " << likelihood;
+}

--- a/tests/log_likelihood_negative.output
+++ b/tests/log_likelihood_negative.output
@@ -1,0 +1,1 @@
+log likelihood: -46.1808


### PR DESCRIPTION
If the ODE solver results in a negative value, then we do not trust that value and it interferes with log-likelihood calculations. The solution is to see that either zero or a *small* positive number is more accurate than the negative number. This occurs by, first, calculating the sum of all positive entries in the solution vector to get a norm. Then when the solution vector is normalized to create a probability mass function, the negative values are replaced with 1e-9*norm.