### PR TITLE
Avoid questionable divisions of integers by integers.

### DIFF
--- a/ode_solver.cpp
+++ b/ode_solver.cpp
@@ -172,7 +172,7 @@ ODE::StepperSDIRK<2>::NewtonFunction::NewtonFunction(const Model::Model &ode_sys
 // FIXME: add comments
 Eigen::VectorXd ODE::StepperSDIRK<2>::NewtonFunction::value(const Eigen::VectorXd &x) const
 {
-  Eigen::VectorXd y = x0 + dt * 1/4 * x;
+  Eigen::VectorXd y = x0 + dt * 1./4 * x;
   return x - ode_system.rhs(y);
 }
 
@@ -191,7 +191,7 @@ Eigen::VectorXd ODE::StepperSDIRK<2>::step_forward(Eigen::VectorXd &x0, double t
   {
     Eigen::MatrixXd jac = ode_system.jacobian(x0);
 
-    Eigen::MatrixXd newton_jacobian = Eigen::MatrixXd::Identity(jac.rows(), jac.cols()) - dt * 1/4 * jac;
+    Eigen::MatrixXd newton_jacobian = Eigen::MatrixXd::Identity(jac.rows(), jac.cols()) - dt * 1./4 * jac;
 
     jacobian_solver = newton_jacobian.partialPivLu();
   }
@@ -201,7 +201,7 @@ Eigen::VectorXd ODE::StepperSDIRK<2>::step_forward(Eigen::VectorXd &x0, double t
   auto newton_result_k1 = newton_method(fcn_k1, jacobian_solver, guess);
   auto k1 = newton_result_k1.first;
 
-  StepperSDIRK<2>::NewtonFunction fcn_k2(ode_system, t, dt, x0 + dt * 1/2 * k1);
+  StepperSDIRK<2>::NewtonFunction fcn_k2(ode_system, t, dt, x0 + dt * 1./2 * k1);
   auto newton_result_k2 = newton_method(fcn_k2, jacobian_solver, guess);
   auto k2 = newton_result_k2.first;
 
@@ -216,7 +216,7 @@ Eigen::VectorXd ODE::StepperSDIRK<2>::step_forward(Eigen::VectorXd &x0, double t
     update_jacobian = true;
   }
 
-  return x0 + dt * 1/2 * k1 + dt * 1/2 * k2;
+  return x0 + dt * 1./2 * k1 + dt * 1./2 * k2;
 }
 
 


### PR DESCRIPTION
An expression such as 
```
  1/4 * dt
```
is read left to right and starts with a division of the integer `1` by the integer `4`, which results in a zero. This is rarely what you actually want in contexts such as these, but that's what the language says should happen. In the contexts I'm changing here, you have
```
  dt * 1/4
```
which first multiplies a floating point number by an integer, resulting in a floating point number, and then a division by an integer, which also results in a floating point number. This expression does what you want, but more by chance than design I suspect :-)

It is good practice to write `1/4` as `1./4.` or `1./4` or just `0.25` to avoid the ambiguity.