### PR TITLE
Expand prior bounds for kb.

### DIFF
--- a/mcmc_3step_all.cpp
+++ b/mcmc_3step_all.cpp
@@ -95,7 +95,7 @@ public:
 
   // { kb, k1, k2, k3 }
   std::vector<Real> lower_bounds = { 0., 1000., 4800., 10., 10.};
-  std::vector<Real> upper_bounds = { 1.e3, 2.e6, 8.e7, 8.5e5, 2.5e5};
+  std::vector<Real> upper_bounds = { 1.e3, 2.e8, 8.e7, 8.5e5, 2.5e5};
 
   // Particle size cutoff should be a non-negative integer, unlike the other parameters.
   unsigned int lower_bound_cutoff = 10;

--- a/mcmc_3step_time1.cpp
+++ b/mcmc_3step_time1.cpp
@@ -94,7 +94,7 @@ public:
 
   // { kb, k1, k2, k3 }
   std::vector<Real> lower_bounds = { 0., 1000., 4800., 10., 10.};
-  std::vector<Real> upper_bounds = { 1.e3, 2.e6, 8.e7, 8.5e5, 2.5e5};
+  std::vector<Real> upper_bounds = { 1.e3, 2.e8, 8.e7, 8.5e5, 2.5e5};
 
   // Particle size cutoff should be a non-negative integer, unlike the other parameters.
   unsigned int lower_bound_cutoff = 10;

--- a/mcmc_3step_time2.cpp
+++ b/mcmc_3step_time2.cpp
@@ -95,7 +95,7 @@ public:
 
   // { kb, k1, k2, k3 }
   std::vector<Real> lower_bounds = { 0., 1000., 4800., 10., 10.};
-  std::vector<Real> upper_bounds = { 1.e3, 2.e6, 8.e7, 8.5e5, 2.5e5};
+  std::vector<Real> upper_bounds = { 1.e3, 2.e8, 8.e7, 8.5e5, 2.5e5};
 
   // Particle size cutoff should be a non-negative integer, unlike the other parameters.
   unsigned int lower_bound_cutoff = 10;

--- a/mcmc_3step_time3.cpp
+++ b/mcmc_3step_time3.cpp
@@ -94,7 +94,7 @@ public:
 
   // { kb, k1, k2, k3 }
   std::vector<Real> lower_bounds = { 0., 1000., 4800., 10., 10.};
-  std::vector<Real> upper_bounds = { 1.e3, 2.e6, 8.e7, 8.5e5, 2.5e5};
+  std::vector<Real> upper_bounds = { 1.e3, 2.e8, 8.e7, 8.5e5, 2.5e5};
 
   // Particle size cutoff should be a non-negative integer, unlike the other parameters.
   unsigned int lower_bound_cutoff = 10;

--- a/mcmc_3step_time4.cpp
+++ b/mcmc_3step_time4.cpp
@@ -94,7 +94,7 @@ public:
 
   // { kb, k1, k2, k3 }
   std::vector<Real> lower_bounds = { 0., 1000., 4800., 10., 10.};
-  std::vector<Real> upper_bounds = { 1.e3, 2.e6, 8.e7, 8.5e5, 2.5e5};
+  std::vector<Real> upper_bounds = { 1.e3, 2.e8, 8.e7, 8.5e5, 2.5e5};
 
   // Particle size cutoff should be a non-negative integer, unlike the other parameters.
   unsigned int lower_bound_cutoff = 10;

--- a/mcmc_4step_all.cpp
+++ b/mcmc_4step_all.cpp
@@ -92,7 +92,7 @@ public:
 
   // { kb, k1, k2, k3, k4 }
   std::vector<Real> lower_bounds = { 0., 1000., 4800., 10., 10., 0.};
-  std::vector<Real> upper_bounds = { 1.e3, 2.e6, 8.e7, 8.5e5, 2.5e5, 2.5e5};
+  std::vector<Real> upper_bounds = { 1.e3, 2.e8, 8.e7, 8.5e5, 2.5e5, 2.5e5};
 
   // Particle size cutoff should be a non-negative integer, unlike the other parameters.
   unsigned int lower_bound_cutoff = 10;


### PR DESCRIPTION
The histogram for kb with the 1.6 million 4-step samples is really pushing up against the upper bound I had set for kb prior to adding kf as a parameter. I'm going to see what the histograms look like for the 3-step and decide if I need to rerun a lot of 4-step samples to get a better representation of the probability distributions.