### PR TITLE
Performance test

### DIFF
--- a/applications/ode_solver_test/comparisons.m
+++ b/applications/ode_solver_test/comparisons.m
@@ -1,5 +1,6 @@
 %% 3-step comparisons
 acc_3step
+fast_3step
 sun_3step
 
 n = 3:2500;
@@ -8,11 +9,13 @@ figure
 plot(d, sol_acc_3(4:end), 'o')
 hold on
 plot(d, sol_sun_3(4:end), 'o')
-legend('accurate','sundials')
+plot(d, sol_fast_3(4:end), 'o')
+legend('accurate','sundials','paper')
 hold off
 
 %%
 acc_4step
+fast_4step
 sun_4step
 
 n = 3:2500;
@@ -21,5 +24,6 @@ figure
 plot(d, sol_acc_4(4:end), 'o')
 hold on
 plot(d, sol_sun_4(4:end), 'o')
-legend('accurate','sundials')
+plot(d, sol_fast_4(4:end), 'o')
+legend('accurate','sundials','paper')
 hold off

--- a/applications/ode_solver_test/ode_solver_test_3step.cpp
+++ b/applications/ode_solver_test/ode_solver_test_3step.cpp
@@ -31,7 +31,7 @@ int main()
   const unsigned int POM_index = 2;
   const unsigned int nucleation_index = 3;
 
-  const Real kf = 3.6e-2;
+  const Real kf = 3.3e-3;
   const Real kb = 6.67e3;
   const Real k1 = 1.26e5;
   const Real k2 = 2.57e5;
@@ -128,7 +128,7 @@ int main()
    ********************************/
 
   // Problem constants
-  const realtype abs_tol = 1e-10;
+  const realtype abs_tol = 1e-12;
   const realtype rel_tol = 1e-6;
   const unsigned int dim = ic.size();
 

--- a/applications/ode_solver_test/ode_solver_test_3step.cpp
+++ b/applications/ode_solver_test/ode_solver_test_3step.cpp
@@ -78,10 +78,10 @@ int main()
   /*******************************************
    * Solve using Eigen as an accuracy baseline
    ******************************************/
-  ODE::StepperBDF<4, Real, Matrix> stepper(three_step_alt);
+  ODE::StepperBDF<4, Real, Matrix> stepper_acc(three_step_alt);
   auto begin = std::chrono::steady_clock::now();
 
-  auto eigen_accurate_solution = ODE::solve_ode(stepper, ic, start_time, end_time, 5e-5);
+  auto eigen_accurate_solution = ODE::solve_ode(stepper_acc, ic, start_time, end_time, 5e-5);
 
   auto end = std::chrono::steady_clock::now();
   std::cout << "Accurate Eigen sparse solve: "
@@ -102,9 +102,10 @@ int main()
   /*******************************************
    * Solve using Eigen as a time baseline
    ******************************************/
+  ODE::StepperBDF<4, Real, Matrix> stepper_fast(three_step_alt);
   begin = std::chrono::steady_clock::now();
 
-  auto eigen_fast_solution = ODE::solve_ode(stepper, ic, start_time, end_time, 5e-3);
+  auto eigen_fast_solution = ODE::solve_ode(stepper_fast, ic, start_time, end_time, 5e-3);
 
   end = std::chrono::steady_clock::now();
   std::cout << "Fast Eigen sparse solve: "
@@ -128,7 +129,7 @@ int main()
    ********************************/
 
   // Problem constants
-  const realtype abs_tol = 1e-12;
+  const realtype abs_tol = 1e-13;
   const realtype rel_tol = 1e-6;
   const unsigned int dim = ic.size();
 

--- a/applications/ode_solver_test/ode_solver_test_4step.cpp
+++ b/applications/ode_solver_test/ode_solver_test_4step.cpp
@@ -139,7 +139,7 @@ int main()
    ********************************/
 
   // Problem constants
-  const realtype abs_tol = 1e-13;
+  const realtype abs_tol = 1e-14;
   const realtype rel_tol = 1e-6;
   const unsigned int dim = ic.size();
 

--- a/applications/ode_solver_test/ode_solver_test_4step.cpp
+++ b/applications/ode_solver_test/ode_solver_test_4step.cpp
@@ -87,10 +87,10 @@ int main()
   /*******************************************
    * Solve using Eigen as an accuracy baseline
    ******************************************/
-  ODE::StepperBDF<4, Real, Matrix> stepper(four_step_alt);
+  ODE::StepperBDF<4, Real, Matrix> stepper_acc(four_step_alt);
   auto begin = std::chrono::steady_clock::now();
 
-  auto eigen_accurate_solution = ODE::solve_ode(stepper, ic, start_time, end_time, 5e-5);
+  auto eigen_accurate_solution = ODE::solve_ode(stepper_acc, ic, start_time, end_time, 5e-5);
 
   auto end = std::chrono::steady_clock::now();
   std::cout << "Accurate Eigen sparse solve: "
@@ -112,9 +112,10 @@ int main()
   /*******************************************
    * Solve using Eigen as a time baseline
    ******************************************/
+  ODE::StepperBDF<4, Real, Matrix> stepper_fast(four_step_alt);
   begin = std::chrono::steady_clock::now();
 
-  auto eigen_fast_solution = ODE::solve_ode(stepper, ic, start_time, end_time, 5e-3);
+  auto eigen_fast_solution = ODE::solve_ode(stepper_fast, ic, start_time, end_time, 5e-3);
 
   end = std::chrono::steady_clock::now();
   std::cout << "Fast Eigen sparse solve: "
@@ -138,7 +139,7 @@ int main()
    ********************************/
 
   // Problem constants
-  const realtype abs_tol = 1e-12;
+  const realtype abs_tol = 1e-13;
   const realtype rel_tol = 1e-6;
   const unsigned int dim = ic.size();
 

--- a/lib/sundials_solvers.h
+++ b/lib/sundials_solvers.h
@@ -286,6 +286,11 @@ namespace sundials
     check_flag(&flag, "CVodeSStolerances",RETURNNONNEGATIVE);
 
 
+    // Set maximum number of steps
+    flag = CVodeSetMaxNumSteps(cvode_mem, initial_condition->ops->nvgetlength(initial_condition)*10);
+    check_flag(&flag, "CVodeSetMaxNumSteps", RETURNNONNEGATIVE);
+
+
     // Attach user data
     flag = CVodeSetUserData(cvode_mem, this);
     check_flag(&flag, "CVodeSetUserData", RETURNNONNEGATIVE);

--- a/lib/sundials_solvers.h
+++ b/lib/sundials_solvers.h
@@ -20,6 +20,7 @@
 
 #include <iostream>
 #include <limits>
+#include <algorithm>
 
 namespace sundials
 {
@@ -287,7 +288,8 @@ namespace sundials
 
 
     // Set maximum number of steps
-    flag = CVodeSetMaxNumSteps(cvode_mem, initial_condition->ops->nvgetlength(initial_condition)*10);
+    sunindextype max_steps = std::max((sunindextype) 500, initial_condition->ops->nvgetlength(initial_condition)*10);
+    flag = CVodeSetMaxNumSteps(cvode_mem, max_steps);
     check_flag(&flag, "CVodeSetMaxNumSteps", RETURNNONNEGATIVE);
 
 


### PR DESCRIPTION
Fixed a few things from #121 and answering the questions @bangerth had.

First off, I had a mistake in my implementation of the ODE solvers. I used the same time stepper for the "accurate" and "fast" solves. The issue is that the BDF stepper uses an SDIRK method until there are enough "previous solutions" to actually do the BDF algorithm. This means that normally SDIRK is used for the first `order-1` time steps and then BDF for the rest. However, in #121 I never cleared out the `previous_solutions` member of `stepper`, so when I was computing the "fast" solve the BDF interpolation was using the last few time steps of the "accurate" solution. Anyway, this caused the "fast" solution from the #121 code to be wildly incorrect.

The result is that the performance difference between the "fast" solve and the SUNDIALS solve is actually somewhat minimal (but maybe will add up over millions of samples). The timing results and the graphs below also include reducing the absolute tolerance from 10^-12 to 10^-13. In addition, SUNDIALS defaults to a maximum of 500 time steps. I changed this to `dimension*10` because 500 time steps were not enough when I reduced the tolerance. All in all, the results are as follows:

```
3-step Mechanism performance:
-----------------------------
Accurate Eigen sparse solve: 28610 milliseconds
Fast Eigen sparse solve: 588 milliseconds
SUNDIALS solve: 404 milliseconds
```
![compare_3step](https://user-images.githubusercontent.com/61596487/129586421-28ba4b62-245c-43e2-bd0e-ea223d2aa790.png)
The oscillations from SUNDIALS are gone, as are the negative values. The three solutions seem to be identical for practical purposes.

```
4-step Mechanism performance:
-----------------------------
Accurate Eigen sparse solve: 44917 milliseconds
Fast Eigen sparse solve: 1627 milliseconds
SUNDIALS solve: 1279 milliseconds
```
The 4-step had very small oscillations near the peak when `atol=10^-13` but with `atol=10^-14` they are eliminated. 
![compare_4step](https://user-images.githubusercontent.com/61596487/129587377-157b695c-56c5-4833-9d51-99704dfe9eb1.png)

Similarly, the negative values and oscillation are gone and the three solutions are basically the same.
